### PR TITLE
Added parallelshell support for running multiple npm commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "scripts": {
     "serve": "http-server",
-    "watch": "watchify src/main.jsx -v -t [ babelify --presets [ es2015 react stage-2 ] ] -o public/js/main.js",
+    "watch:jsx": "watchify src/main.jsx -v -t [ babelify --presets [ es2015 react stage-2 ] ] -o public/js/main.js",
     "build": "browserify -t [ babelify --presets [ es2015 react stage-2 ] ] src/main.jsx -o public/js/main.js",
     "watch:scss": "sass --watch src/scss:public/css",
+    "watch": "parallelshell 'npm run watch:jsx' 'npm run watch:scss'",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -29,6 +30,7 @@
     "babel-preset-stage-2": "6.5.0",
     "babelify": "7.2.0",
     "browserify": "13.0.0",
+    "parallelshell": "^2.0.0",
     "redux-devtools": "3.1.1",
     "sass": "^0.5.0",
     "watchify": "3.7.0"


### PR DESCRIPTION
Run `npm install` to install parallelshell

Now a simple `npm run watch` watches both jsx and scss at the same time
